### PR TITLE
Make Google DNS provider for pi-hole container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,4 @@ services:
       TZ: 'Europe/Berlin'
       FTLCONF_dns_listeningMode: 'all'
     dns:
-      - 127.0.0.1
+      - 8.8.8.8


### PR DESCRIPTION
Fixes broken gravity updates when using itself as DNS server.