### PR TITLE
Add Odoo and clean up Caddy config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,8 +7,11 @@ EMAIL=handle@example.com
 # Path for all docker volumes
 DOCKER_VOLUMES=~/docker_volumes
 
-# Path for backup zip archives
+# Backup settings
 BACKUP_DIR=~/docker_volumes_backups  
+BACKUP_PASSWORD=your_pw_here
 
-# Password for backup zip archives
-PASSWORD_BACKUP=your_pw_here         
+# Odoo/Postgres database settings
+POSTGRES_DB=postgres
+POSTGRES_USER=odoo
+POSTGRES_PASSWORD=odoo

--- a/Caddyfile
+++ b/Caddyfile
@@ -9,18 +9,23 @@
 }
 
 {$DOMAIN} {
-	# handle_path /vault/notifications/hub* {
-	#   reverse_proxy vaultwarden:3012
-	# }
-
-	handle_path /vault* {
-		reverse_proxy vaultwarden:80 {
-			header_up X-Real-IP {remote_host}
-		}
+	@rootPath path "/"
+	header @rootPath Content-Type "text/html"
+	respond @rootPath "<!DOCTYPE html><html><head><title>Homelab Services</title></head><body><h1>Welcome</h1><ul><li><a href='{$DOMAIN}:314'>Pihole</a></li><li><a href='{$DOMAIN}:315'>Vaultwarden</a></li><li><a href='{$DOMAIN}:316'>Odoo</a></li></ul></body></html>" 200 {
 	}
 }
 
 {$DOMAIN}:314 {
 	redir / /admin{uri}
 	reverse_proxy pihole:80
+}
+
+{$DOMAIN}:315 {
+	reverse_proxy vaultwarden:80 {
+		header_up X-Real-IP {remote_host}
+	}
+}
+
+{$DOMAIN}:316 {
+	reverse_proxy odoo:8069
 }

--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ docker exec -it pihole pihole -a -p
 ```
 
 on the host.
+
+### :books: Odoo
+
+To generate pdfs, it might be necessary to set the system parameter `report.url` to `http://0.0.0.0:8069`, see [here](https://github.com/odoo/docker/issues/238#issuecomment-457216876).

--- a/backup_create.sh
+++ b/backup_create.sh
@@ -13,7 +13,7 @@ docker-compose -f ./docker-compose.yml down
 
 # Create a zip backup with a password
 echo "Creating backup..."
-zip -r -P "$PASSWORD_BACKUP" "$BACKUP_FILE" "$DOCKER_VOLUMES"
+zip -r -P "$BACKUP_PASSWORD" "$BACKUP_FILE" "$DOCKER_VOLUMES"
 
 # Start all containers again
 echo "Starting containers..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "${DOCKER_VOLUMES}/vaultwarden:/data"
     environment:
       DOMAIN: "${DOMAIN}"
-      # ADMIN_TOKEN: "${ADMIN_TOKEN}"
       ORG_CREATION_USERS: "${EMAIL}"
       SIGNUPS_ALLOWED: "false"
       EXPERIMENTAL_CLIENT_FEATURE_FLAGS: "ssh-key-vault-item"
@@ -48,3 +47,30 @@ services:
       FTLCONF_dns_listeningMode: "all"
     dns:
       - 8.8.8.8
+  odoo:
+    container_name: odoo
+    image: odoo:18
+    depends_on:
+      - postgres
+    ports:
+      - "8069:8069"
+    environment:
+      HOST: postgres
+      USER: ${POSTGRES_USER}
+      PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - "${DOCKER_VOLUMES}/odoo/data:/var/lib/odoo"
+      - "${DOCKER_VOLUMES}/odoo/config:/etc/odoo"
+    restart: always
+  postgres:
+    container_name: postgres
+    image: postgres:16
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - "${DOCKER_VOLUMES}/postgres/db:/var/lib/postgresql/data"
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       - "80:80"  # Needed for the ACME HTTP-01 challenge.
       - "443:443"
       - "443:443/udp"  # Needed for HTTP/3.
-      - "314:314"
+      - "314:314"  # Pihole
+      - "315:315"  # Vaultwarden
+      - "316:316"  # Odoo
     volumes:
       - "${DOCKER_VOLUMES}/caddy/Caddyfile:/etc/caddy/Caddyfile"
       - "${DOCKER_VOLUMES}/caddy/config:/config"
@@ -52,8 +54,6 @@ services:
     image: odoo:18
     depends_on:
       - postgres
-    ports:
-      - "8069:8069"
     environment:
       HOST: postgres
       USER: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       - "${DOCKER_VOLUMES}/odoo/data:/var/lib/odoo"
       - "${DOCKER_VOLUMES}/odoo/config:/etc/odoo"
     restart: always
+    dns:
+      - 8.8.8.8
   postgres:
     container_name: postgres
     image: postgres:16


### PR DESCRIPTION
This pull request introduces several changes to enhance the configuration and functionality of a homelab setup. Key updates include the addition of Odoo and PostgreSQL services, improvements to the backup process, and modifications to the `Caddyfile` to provide a user-friendly homepage for accessing services. Below is a summary of the most important changes grouped by theme.

### Service Configuration Updates:
* Added Odoo and PostgreSQL services to `docker-compose.yml`, including environment variables, volumes, and restart policies. This enables the integration of Odoo with PostgreSQL for database management.
* Updated port mappings in `docker-compose.yml` to include ports for Odoo (`316`) and Vaultwarden (`315`) alongside existing services.

### Backup Process Improvements:
* Replaced the `PASSWORD_BACKUP` variable with `BACKUP_PASSWORD` in `backup_create.sh` for consistency with `.env.template`.
* Updated `.env.template` to include `BACKUP_PASSWORD` and PostgreSQL-related variables (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) for better configuration management.

### Web Interface Enhancements:
* Modified the `Caddyfile` to add a homepage displaying links to services (Pihole, Vaultwarden, Odoo) for easier navigation.

### Documentation Updates:
* Added instructions in `README.md` for configuring Odoo's `report.url` system parameter to enable PDF generation.